### PR TITLE
Add more fuzz targets

### DIFF
--- a/projects/guava/HashingFuzzer.java
+++ b/projects/guava/HashingFuzzer.java
@@ -159,10 +159,6 @@ public class HashingFuzzer {
 			testHash(Hashing.crc32(), hashInputData);
 			testHash(Hashing.crc32c(), hashInputData);
 			testHash(Hashing.farmHashFingerprint64(), hashInputData);
-			//// undocumented exception with minimumBits < 0
-			//if (minimumBits <= 0) { 
-			//	minimumBits = 1 - minimumBits;
-			//}
 			testHash(Hashing.goodFastHash(minimumBits), hashInputData);
 			testHash(Hashing.murmur3_128(), hashInputData);
 			testHash(Hashing.murmur3_128(seed), hashInputData);

--- a/projects/guava/HashingFuzzer.java
+++ b/projects/guava/HashingFuzzer.java
@@ -1,0 +1,182 @@
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import java.lang.IllegalStateException;
+
+public class HashingFuzzer {
+
+	public static class HashInputData {
+
+		public HashInputData(FuzzedDataProvider fuzzedDataProvider) {
+			m_bool = fuzzedDataProvider.consumeBoolean();
+			m_bytes = fuzzedDataProvider.consumeBytes(2);
+			m_char = fuzzedDataProvider.consumeChar();
+			m_double = fuzzedDataProvider.consumeDouble();
+			m_float = fuzzedDataProvider.consumeFloat();
+			m_int = fuzzedDataProvider.consumeInt();
+			m_long = fuzzedDataProvider.consumeLong();
+			m_short = fuzzedDataProvider.consumeShort();
+			m_string = fuzzedDataProvider.consumeRemainingAsString();
+		}
+
+		public boolean getBoolean() {
+			return m_bool;
+		}
+
+		public byte getByte() {
+			return (m_bytes.length > 0) ? m_bytes[0] : (byte)m_int;
+		}
+
+		public byte[] getBytes() {
+			return m_bytes;
+		}
+
+		public char getChar() {
+			return m_char;
+		}
+
+		public double getDouble() {
+			return m_double;
+		}
+
+		public float getFloat() {
+			return m_float;
+		}
+
+		public int getInt() {
+			return m_int;
+		}
+
+		public long getLong() {
+			return m_long;
+		}
+
+		public short getShort() {
+			return m_short;
+		}
+
+		public String getString() {
+			return m_string;
+		}
+
+		private boolean m_bool;
+		private byte m_bytes[];
+		private char m_char;
+		private double m_double;
+		private float m_float;
+		private int m_int;
+		private long m_long;
+		private short m_short;
+		private String m_string;
+	}
+
+	private static void testHashCode(HashCode hc) {
+		try {
+			hc.bits();
+
+			try {
+				int i = hc.asInt();
+				HashCode.fromInt(i);
+			} catch (IllegalStateException ise) {
+				/* documented, ignore */
+			}
+
+			try {
+				long l = hc.asLong();
+				HashCode.fromLong(l);
+			} catch (IllegalStateException ise) {
+				/* documented, ignore */
+			}
+
+			hc.padToLong();
+			byte[] bytes = hc.asBytes();
+			hc.writeBytesTo(bytes,0,bytes.length);
+			HashCode.fromBytes(bytes);
+
+			String s = hc.toString();
+			HashCode.fromString(s);
+
+			hc.hashCode();
+		} catch (Exception e) {
+			throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+		}
+	}
+
+	private static void testHash(HashFunction hash, HashInputData hashInputData) {
+		HashCode hc = null;
+		try {
+			Hasher h = hash.newHasher();
+			h.putBoolean(hashInputData.getBoolean());
+			h.putByte(hashInputData.getByte());
+			h.putBytes(hashInputData.getBytes());
+			h.putChar(hashInputData.getChar());
+			h.putDouble(hashInputData.getDouble());
+			h.putFloat(hashInputData.getFloat());
+			h.putInt(hashInputData.getInt());
+			h.putLong(hashInputData.getLong());
+			h.putShort(hashInputData.getShort());
+			h.putUnencodedChars(hashInputData.getString());
+			hc = h.hash();
+		} catch (Exception e) {
+			throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+		}
+
+		if (hc != null) {
+			testHashCode(hc);
+		}
+
+		/*
+		 * fromString documents it accepts only well-formated input,
+		 * but doesn't document what it does when ill-formated input
+		 * is provided. Feed it some fuzz data and find out.
+		 */
+		try {
+			HashCode.fromString(hashInputData.getString());
+		} catch(Exception e) {
+			throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+		}
+	}
+
+	public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) {
+		int minimumBits = fuzzedDataProvider.consumeInt();
+		int seed = fuzzedDataProvider.consumeInt();
+		int k0 = fuzzedDataProvider.consumeInt();
+		int k1 = fuzzedDataProvider.consumeInt();
+
+		HashInputData hashInputData = new HashInputData(fuzzedDataProvider);
+
+		/*
+		 * testHash handles exceptions itself, so this try-block
+		 * only catches exceptions thrown by Hashing's "factory"
+		 * functions, none of which is documented to throw
+		 * exceptions
+		 */
+		try {
+			testHash(Hashing.adler32(), hashInputData);
+			testHash(Hashing.crc32(), hashInputData);
+			testHash(Hashing.crc32c(), hashInputData);
+			testHash(Hashing.farmHashFingerprint64(), hashInputData);
+			//// undocumented exception with minimumBits < 0
+			//if (minimumBits <= 0) { 
+			//	minimumBits = 1 - minimumBits;
+			//}
+			testHash(Hashing.goodFastHash(minimumBits), hashInputData);
+			testHash(Hashing.murmur3_128(), hashInputData);
+			testHash(Hashing.murmur3_128(seed), hashInputData);
+			testHash(Hashing.murmur3_32(), hashInputData);
+			testHash(Hashing.murmur3_32(seed), hashInputData);
+			testHash(Hashing.md5(), hashInputData);
+			testHash(Hashing.sha1(), hashInputData);
+			testHash(Hashing.sha256(), hashInputData);
+			testHash(Hashing.sha384(), hashInputData);
+			testHash(Hashing.sha512(), hashInputData);
+			testHash(Hashing.sipHash24(), hashInputData);
+			testHash(Hashing.sipHash24(k0, k1), hashInputData);
+		} catch (Exception e) {
+			throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+		}
+	}
+}

--- a/projects/guava/HostAndPortFuzzer.java
+++ b/projects/guava/HostAndPortFuzzer.java
@@ -1,0 +1,17 @@
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium;
+import com.google.common.net.HostAndPort;
+import java.lang.IllegalArgumentException;
+
+public class HostAndPortFuzzer {
+	public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+		try {
+			HostAndPort hap = HostAndPort.fromString(data.consumeRemainingAsString());
+		} catch (IllegalArgumentException e) {
+			/* documented to be thrown, ignore */
+	    } catch (Exception e) {
+			e.printStackTrace(System.out);
+			throw new FuzzerSecurityIssueMedium();
+		}
+	}
+}

--- a/projects/guava/HostSpecifierFuzzer.java
+++ b/projects/guava/HostSpecifierFuzzer.java
@@ -1,0 +1,26 @@
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium;
+import com.google.common.net.HostSpecifier;
+import java.text.ParseException;
+
+public class HostSpecifierFuzzer {
+	public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+		try {
+			HostSpecifier hs = HostSpecifier.from(data.consumeRemainingAsString());
+
+			/*
+			 * hs.toString() is a valid string, as otherwise the
+			 * HostSpecifier.from() invocation to initialize hs
+			 * would have thrown an exception.
+			 */
+			if (! HostSpecifier.isValid(hs.toString())) {
+				throw new FuzzerSecurityIssueMedium("toString() generated a poor host specifier");
+			}
+			hs.hashCode();
+		} catch (ParseException e) {
+			/* documented to be thrown, ignore */
+	    } catch (Exception e) {
+			throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+		}
+	}
+}

--- a/projects/guava/InetAddressesFuzzer.java
+++ b/projects/guava/InetAddressesFuzzer.java
@@ -1,26 +1,125 @@
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium;
 import com.google.common.net.InetAddresses;
 import java.lang.IllegalArgumentException;
 import java.net.InetAddress;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.UnknownHostException;
 
 public class InetAddressesFuzzer {
-    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-	    String value = data.consumeRemainingAsString();
-        InetAddress addr;
 
+    private static void testInet6ApiSpecificMethods(InetAddress inaddr) {
+        Inet6Address inet6 = null;
+        if ((inaddr != null) && (inaddr instanceof Inet6Address)) {
+            inet6 = (Inet6Address)inaddr;
+        }
+            
+        if (inet6 != null) {
+            try {
+                InetAddresses.getEmbeddedIPv4ClientAddress(inet6);
+            } catch (IllegalArgumentException e) {
+                /* documented, ignore */
+            } catch (Exception e) {
+                throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+            }
+
+            try {
+                InetAddresses.TeredoInfo teredoInfo = InetAddresses.getTeredoInfo(inet6);
+                teredoInfo.getServer();
+                teredoInfo.getClient();
+                teredoInfo.getPort();
+                teredoInfo.getFlags();
+            } catch (IllegalArgumentException  e) {
+                /* documented, ignore */
+            } catch (Exception e) {
+                throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+            }
+
+            try {
+                InetAddresses.getCoercedIPv4Address(inet6);
+            } catch (Exception e) {
+                throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+            }
+        }
+    }
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+	    
+        InetAddress in6 = null;
+        InetAddress in4 = null;
+        try {
+            in6 = InetAddresses.fromLittleEndianByteArray(data.consumeBytes(16));
+            in4 = InetAddresses.fromLittleEndianByteArray(data.consumeBytes(4));
+        } catch (UnknownHostException e) {
+            /* documented, ignore */
+        } catch (Exception e) {
+            throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+        }
+
+        testInet6ApiSpecificMethods(in6);
+
+        String value = data.consumeRemainingAsString();
+        InetAddress addr = null, uriAddr = null;
+
+        try {
+            uriAddr = InetAddresses.forUriString(value);
+            addr = InetAddresses.forString(value);
+        } catch (IllegalArgumentException e) {
+            /* documented, ignore */
+        } catch (Exception e) {
+            throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+        }
+
+        /*
+         * these don't throw exceptions
+         */
         try {
             InetAddresses.isInetAddress(value);
             InetAddresses.isUriInetAddress(value);
             InetAddresses.isMappedIPv4Address(value);
-            InetAddresses.forUriString(value);
             InetAddresses.isMappedIPv4Address(value);
+        } catch (Exception e) {
+            throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+        }
+        
+        if (addr != null) {
+            /*
+             * these don't throw exceptions, either, but need a valid
+             * InetAddress instance
+             */
+            try {
+                InetAddresses.toUriString(addr);
+                InetAddresses.toAddrString(addr);
+                InetAddresses.coerceToInteger(addr);
+            } catch (Exception e) {
+                throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+            }
 
-            addr = InetAddresses.forString(value);
-            InetAddresses.toUriString(addr);
-            InetAddresses.toAddrString(addr);
-            InetAddresses.increment(addr);
-            InetAddresses.decrement(addr);
+            try {
+                InetAddresses.increment(addr);
+                InetAddresses.decrement(addr);
+            } catch (IllegalArgumentException e) {
+                /* documented, ignore */
+            } catch (Exception e) {
+                throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+            }
 
-        } catch (IllegalArgumentException e) { }
+            try {
+                InetAddresses.fromIPv6BigInteger(InetAddresses.toBigInteger(addr));
+            } catch (IllegalArgumentException e) {
+                /* documented, ignore */
+            } catch (Exception e) {
+                throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+            }
+
+            try {
+                InetAddresses.fromIPv4BigInteger(InetAddresses.toBigInteger(addr));
+            } catch (IllegalArgumentException e) {
+                /* documented, ignore */
+            } catch (Exception e) {
+                throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+            }
+        }
 	} 
 }

--- a/projects/guava/InternetDomainNameFuzzer.java
+++ b/projects/guava/InternetDomainNameFuzzer.java
@@ -1,0 +1,70 @@
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium;
+import com.google.common.net.InternetDomainName;
+import java.lang.IllegalArgumentException;
+import java.lang.IllegalStateException;
+
+public class InternetDomainNameFuzzer {
+	private static void testAccessorMethods(InternetDomainName idn) {
+		idn.parts();
+		idn.isPublicSuffix();
+		idn.hasPublicSuffix();
+		idn.publicSuffix();
+		idn.isUnderPublicSuffix();
+		idn.isTopPrivateDomain();
+		try {
+			idn.topPrivateDomain();
+		} catch(IllegalStateException e) {
+			/* documented, ignore */
+		}
+		idn.isRegistrySuffix();
+		idn.hasRegistrySuffix();
+		idn.registrySuffix();
+		idn.isUnderRegistrySuffix();
+		idn.isTopDomainUnderRegistrySuffix();
+		try {
+			idn.topDomainUnderRegistrySuffix();
+		} catch(IllegalStateException e) {
+			/* documented, ignore */
+		}
+		idn.hasParent();
+		try {
+			idn.parent();
+		} catch(IllegalStateException e) {
+			/* documented, ignore */
+		}
+		idn.hashCode();
+	}
+
+	public static void testChild(InternetDomainName idn, String leftParts) {
+		try {
+			idn.child(leftParts);
+		} catch(IllegalArgumentException e) {
+			/* documented, ignore */
+		} catch(NullPointerException e) {
+			/* documented, ignore */
+		}
+	}
+
+	public static void fuzzerTestOneInput(FuzzedDataProvider dataProvider) {
+		
+		try {
+			InternetDomainName idn;
+			try {
+				idn = InternetDomainName.from(dataProvider.consumeString(dataProvider.remainingBytes()));
+			} catch (IllegalArgumentException e) {
+				/*
+				 * documented to be thrown, ignore
+				 */
+				return;
+			}
+
+			testAccessorMethods(idn);
+			testChild(idn, dataProvider.consumeString(dataProvider.remainingBytes()));
+
+	    } catch (Exception e) {
+			e.printStackTrace(System.out);
+			throw new FuzzerSecurityIssueMedium("Undocumented Exception");
+		}
+	}
+}

--- a/projects/guava/build.sh
+++ b/projects/guava/build.sh
@@ -34,6 +34,9 @@ for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
   fuzzer_basename=$(basename -s .java $fuzzer)
   javac -cp $BUILD_CLASSPATH $fuzzer
   cp $SRC/$fuzzer_basename.class $OUT/
+  for member_class in $(find $SRC -name "$fuzzer_basename\$*.class"); do
+    cp $member_class $OUT/
+  done
 
   # Create an execution wrapper that executes Jazzer with the correct arguments.
   echo "#!/bin/sh

--- a/projects/guava/project.yaml
+++ b/projects/guava/project.yaml
@@ -11,3 +11,4 @@ vendor_ccs:
   - "yakdan@code-intelligence.com"
   - "glendowne@code-intelligence.com"
   - "patrice.salathe@code-intelligence.com"
+  - "alonsoschaich@fastmail.fm"


### PR DESCRIPTION
Add more fuzz targets, mostly for the [com.google.common.net](https://javadoc.scijava.org/Guava/com/google/common/net/package-frame.html) package

The new HashingFuzzer discovers 3 "interesting" behaviours:
 * [Hashing.murmur3_128](https://javadoc.scijava.org/Guava/com/google/common/hash/Hashing.html#murmur3_128--) needs excessive amounts of memories, exhausting the JVM for some inputs
 * [Hashing.goodFastHash](https://javadoc.scijava.org/Guava/com/google/common/hash/Hashing.html#goodFastHash-int-) throws exceptions for poor values of *minimumBits*, which is not documented
 * [HashCode.fromString](https://javadoc.scijava.org/Guava/com/google/common/hash/HashCode.html#fromString-java.lang.String-) throws exceptions for poor values of *string*, which is not documented