### PR TITLE
Added fuzz targets for Apache's HttpClient Mime

### DIFF
--- a/projects/httpcomponents-client/Dockerfile
+++ b/projects/httpcomponents-client/Dockerfile
@@ -29,4 +29,4 @@ RUN git clone --depth 1 https://github.com/apache/httpcomponents-core
 RUN git clone --depth 1 https://github.com/qos-ch/slf4j
 
 COPY build.sh $SRC/
-COPY HttpFuzzer.java $SRC/
+COPY *Fuzzer.java $SRC/

--- a/projects/httpcomponents-client/FileBodyWriteToFuzzer.java
+++ b/projects/httpcomponents-client/FileBodyWriteToFuzzer.java
@@ -1,0 +1,54 @@
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueLow;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.apache.hc.client5.http.entity.mime.FileBody;
+import org.apache.hc.core5.http.ContentType;
+
+public class FileBodyWriteToFuzzer {
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        // Create objects from fuzzer input
+        final ContentType contentType = data.pickValue(contentTypes);
+        final String filename = data.consumeString(255);
+        final String fileContent = data.consumeRemainingAsString();
+
+        // Create needed objects
+        final File tempFile;
+        try {
+            tempFile = File.createTempFile("FileBody", "bin");
+            tempFile.deleteOnExit();
+
+            final FileWriter fileWriter = new FileWriter(tempFile);
+            fileWriter.write(fileContent);
+            fileWriter.close();
+        } catch (IOException ioe) {
+            // Preparations failed ; exit early
+            return;
+        }
+
+        // Actual fuzzing begins here
+        try {
+            final FileBody fileBody = new FileBody(tempFile, contentType, filename);
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+            fileBody.writeTo(outputStream);
+        } catch (IOException ignored) {
+            // ignore expected exceptions
+        }
+    }
+
+    private static final ContentType[] contentTypes = {ContentType.APPLICATION_ATOM_XML,
+        ContentType.APPLICATION_FORM_URLENCODED, ContentType.APPLICATION_JSON, ContentType.APPLICATION_NDJSON,
+        ContentType.APPLICATION_OCTET_STREAM, ContentType.APPLICATION_PDF, ContentType.APPLICATION_PROBLEM_JSON,
+        ContentType.APPLICATION_PROBLEM_XML, ContentType.APPLICATION_RSS_XML, ContentType.APPLICATION_SOAP_XML,
+        ContentType.APPLICATION_SVG_XML, ContentType.APPLICATION_XHTML_XML, ContentType.APPLICATION_XML,
+        ContentType.DEFAULT_BINARY, ContentType.DEFAULT_TEXT, ContentType.IMAGE_BMP, ContentType.IMAGE_GIF,
+        ContentType.IMAGE_JPEG, ContentType.IMAGE_PNG, ContentType.IMAGE_SVG, ContentType.IMAGE_TIFF,
+        ContentType.IMAGE_WEBP, ContentType.MULTIPART_FORM_DATA, ContentType.MULTIPART_MIXED,
+        ContentType.MULTIPART_RELATED, ContentType.TEXT_EVENT_STREAM, ContentType.TEXT_HTML, ContentType.TEXT_MARKDOWN,
+        ContentType.TEXT_PLAIN, ContentType.TEXT_XML, ContentType.WILDCARD};
+}

--- a/projects/httpcomponents-client/FormBodyPartBuilderBuildFuzzer.java
+++ b/projects/httpcomponents-client/FormBodyPartBuilderBuildFuzzer.java
@@ -1,0 +1,87 @@
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.hc.client5.http.entity.mime.ByteArrayBody;
+import org.apache.hc.client5.http.entity.mime.ContentBody;
+import org.apache.hc.client5.http.entity.mime.FileBody;
+import org.apache.hc.client5.http.entity.mime.FormBodyPartBuilder;
+import org.apache.hc.client5.http.entity.mime.InputStreamBody;
+import org.apache.hc.client5.http.entity.mime.StringBody;
+import org.apache.hc.core5.http.ContentType;
+
+public class FormBodyPartBuilderBuildFuzzer {
+    private static final int builderNameLength = 255;
+    private static final int fieldNameLength = 255;
+    private static final int fieldValueLength = 500;
+    private static final int bodyContentSize = 2 * fieldValueLength;
+
+    private enum BodyType { ByteArray, File, InputStream, String }
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        final String builderName = data.consumeString(builderNameLength);
+        final ContentBody contentBody;
+        try {
+            contentBody = generateContentBody(data);
+        } catch (IOException ioe) {
+            // preparations failed ; exit early
+            return;
+        };
+
+        try {
+            final FormBodyPartBuilder builder =
+                FormBodyPartBuilder.create(builderName, contentBody);
+
+            while (data.remainingBytes() > 0) {
+                builder.addField(
+                    data.consumeString(fieldNameLength), data.consumeString(fieldValueLength));
+            }
+
+            builder.build();
+        } catch (IllegalStateException ignored) {
+            return;
+        }
+    }
+
+    private static ContentBody generateContentBody(FuzzedDataProvider data) throws IOException {
+        final BodyType choice = data.pickValue(BodyType.values());
+        final ContentBody contentBody;
+        switch (choice) {
+            case ByteArray:
+                contentBody = new ByteArrayBody(
+                    data.consumeBytes(bodyContentSize), data.consumeString(fieldNameLength));
+                break;
+
+            case File:
+                final File tempFile = File.createTempFile("FileBody", "bin");
+                tempFile.deleteOnExit();
+                final FileWriter fileWriter = new FileWriter(tempFile);
+                fileWriter.write(data.consumeString(bodyContentSize));
+                fileWriter.close();
+
+                contentBody = new FileBody(tempFile);
+                break;
+
+            case InputStream:
+                final InputStream inputStream =
+                    new ByteArrayInputStream(data.consumeBytes(bodyContentSize));
+                contentBody = new InputStreamBody(inputStream, data.consumeString(fieldNameLength));
+                break;
+
+            case String:
+                contentBody =
+                    new StringBody(data.consumeString(bodyContentSize), ContentType.DEFAULT_BINARY);
+                break;
+
+            default: // should never be reached
+                contentBody = null;
+                break;
+        }
+
+        return contentBody;
+    }
+}

--- a/projects/httpcomponents-client/HeaderAddFieldFuzzer.java
+++ b/projects/httpcomponents-client/HeaderAddFieldFuzzer.java
@@ -1,0 +1,18 @@
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import org.apache.hc.client5.http.entity.mime.Header;
+import org.apache.hc.client5.http.entity.mime.MimeField;
+
+public class HeaderAddFieldFuzzer {
+    private static final int MAX_NAME_LENGTH = 300;
+    private static final int MAX_VALUE_LENGTH = 700;
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        final Header header = new Header();
+
+        while (data.remainingBytes() > 0) {
+            header.addField(new MimeField(
+                data.consumeString(MAX_NAME_LENGTH), data.consumeString(MAX_VALUE_LENGTH)));
+        }
+    }
+}

--- a/projects/httpcomponents-client/HeaderRemoveFieldsFuzzer.java
+++ b/projects/httpcomponents-client/HeaderRemoveFieldsFuzzer.java
@@ -1,0 +1,53 @@
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import org.apache.hc.client5.http.entity.mime.Header;
+import org.apache.hc.client5.http.entity.mime.MimeField;
+
+public class HeaderRemoveFieldsFuzzer {
+    private static final int MAX_NAME_LENGTH = 50;
+    private static final int MAX_VALUE_LENGTH = 300;
+    private static final int MIN_ARRAYLIST_CAPACITY = 5;
+    private static final int MAX_ARRAYLIST_CAPACITY = 700;
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        final int arrayCapacity = data.consumeInt(MIN_ARRAYLIST_CAPACITY, MAX_ARRAYLIST_CAPACITY);
+        final int numberOfMimeFields = data.consumeInt(1, arrayCapacity);
+        final ArrayList<MimeField> mimeFields =
+            generateMimeFields(arrayCapacity, numberOfMimeFields, data);
+
+        final Header header = new Header();
+        for (MimeField mimeField : mimeFields) {
+            header.addField(mimeField);
+        }
+
+        for (MimeField mimeField : mimeFields) {
+            header.removeFields(mimeField != null ? mimeField.getName() : null);
+        }
+    }
+
+    private static ArrayList<MimeField> generateMimeFields(
+        int arrayCapacity, int numberOfMimeFields, FuzzedDataProvider data) {
+        final ArrayList<MimeField> mimeFields = new ArrayList<>(arrayCapacity);
+
+        int counter = 0;
+        for (int i = 0; i < arrayCapacity; i++) {
+            final MimeField mimeField;
+            if (counter < numberOfMimeFields) {
+                mimeField = new MimeField(
+                    data.consumeString(MAX_NAME_LENGTH), data.consumeString(MAX_VALUE_LENGTH));
+                counter++;
+            } else {
+                mimeField = null;
+            }
+
+            mimeFields.add(mimeField);
+        }
+
+        Collections.shuffle(mimeFields);
+
+        return mimeFields;
+    }
+}

--- a/projects/httpcomponents-client/InputStreamBodyWriteToFuzzer.java
+++ b/projects/httpcomponents-client/InputStreamBodyWriteToFuzzer.java
@@ -1,0 +1,45 @@
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.hc.client5.http.entity.mime.InputStreamBody;
+import org.apache.hc.core5.http.ContentType;
+
+public class InputStreamBodyWriteToFuzzer {
+    private static final int FILENAME_MAX_LENGTH = 255;
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        // Create objects from fuzzer input
+        final ContentType contentType = data.pickValue(contentTypes);
+        final String filename = data.consumeString(FILENAME_MAX_LENGTH);
+        final long contentLength = data.consumeLong();
+        final InputStream inputStream =
+            new ByteArrayInputStream(data.consumeBytes(Integer.MAX_VALUE));
+
+        // Create needed objects
+        final InputStreamBody inputStreamBody =
+            new InputStreamBody(inputStream, contentType, filename, contentLength);
+
+        try {
+            inputStreamBody.writeTo(new ByteArrayOutputStream());
+        } catch (IOException ignored) {
+            // ignore expected exceptions
+        }
+    }
+
+    private static final ContentType[] contentTypes = {ContentType.APPLICATION_ATOM_XML,
+        ContentType.APPLICATION_FORM_URLENCODED, ContentType.APPLICATION_JSON,
+        ContentType.APPLICATION_NDJSON, ContentType.APPLICATION_OCTET_STREAM,
+        ContentType.APPLICATION_PDF, ContentType.APPLICATION_PROBLEM_JSON,
+        ContentType.APPLICATION_PROBLEM_XML, ContentType.APPLICATION_RSS_XML,
+        ContentType.APPLICATION_SOAP_XML, ContentType.APPLICATION_SVG_XML,
+        ContentType.APPLICATION_XHTML_XML, ContentType.APPLICATION_XML, ContentType.DEFAULT_BINARY,
+        ContentType.DEFAULT_TEXT, ContentType.IMAGE_BMP, ContentType.IMAGE_GIF,
+        ContentType.IMAGE_JPEG, ContentType.IMAGE_PNG, ContentType.IMAGE_SVG,
+        ContentType.IMAGE_TIFF, ContentType.IMAGE_WEBP, ContentType.MULTIPART_FORM_DATA,
+        ContentType.MULTIPART_MIXED, ContentType.MULTIPART_RELATED, ContentType.TEXT_EVENT_STREAM,
+        ContentType.TEXT_HTML, ContentType.TEXT_MARKDOWN, ContentType.TEXT_PLAIN,
+        ContentType.TEXT_XML, ContentType.WILDCARD};
+}

--- a/projects/httpcomponents-client/MimeFieldToStringFuzzer.java
+++ b/projects/httpcomponents-client/MimeFieldToStringFuzzer.java
@@ -1,0 +1,17 @@
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import org.apache.hc.client5.http.entity.mime.MimeField;
+
+public class MimeFieldToStringFuzzer {
+    private static final int nameLength = 300;
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        // Create objects from fuzzer input
+        final String name = data.consumeString(nameLength);
+        final String value = data.consumeRemainingAsString();
+
+        // fuzzing begins here
+        final MimeField mimeField = new MimeField(name, value);
+        mimeField.toString();
+    }
+}

--- a/projects/httpcomponents-client/build.sh
+++ b/projects/httpcomponents-client/build.sh
@@ -47,7 +47,7 @@ RUNTIME_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "\$this_dir/%s:"):\$this_di
 for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
   fuzzer_basename=$(basename -s .java $fuzzer)
   javac -cp $BUILD_CLASSPATH $fuzzer
-  cp $SRC/$fuzzer_basename.class $OUT/
+  cp $SRC/$fuzzer_basename*.class $OUT/
 
   # Create an execution wrapper that executes Jazzer with the correct arguments.
   echo "#!/bin/sh

--- a/projects/httpcomponents-client/project.yaml
+++ b/projects/httpcomponents-client/project.yaml
@@ -11,3 +11,4 @@ vendor_ccs:
 - yakdan@code-intelligence.com
 - glendowne@code-intelligence.com
 - hlin@code-intelligence.com
+- yoshi.weber@gmail.com


### PR DESCRIPTION
I wrote fuzz targets for:
- FileBody.writeTo
- InputStreamBody.writeTo
- FormBodyPartBuilder.build
- MimeField.toString
- Header.addField
- Header.removeFields