### PR TITLE
Small fix in build.sh

### DIFF
--- a/projects/spring-security/build.sh
+++ b/projects/spring-security/build.sh
@@ -45,7 +45,6 @@ index c4f6c08..413b992 100644
  	optional "org.apache.directory.server:apacheds-protocol-shared"
 EOM
 
-# pipe into true to make subsequent executions of build.sh inside the docker shell possible
 git apply patch.diff
 
 


### PR DESCRIPTION
Forgot to remove comment.
It was used during debugging, but the change that it is referring to was removed before creating my the PR.
The comment is now misleading the reader.