### PR TITLE
Fixed javadocs url

### DIFF
--- a/docs/getting-started/new-project-guide/jvm_lang.md
+++ b/docs/getting-started/new-project-guide/jvm_lang.md
@@ -182,4 +182,4 @@ public class ExampleFuzzer {
 ```
 
 For a list of convenience methods offered by `FuzzedDataProvider`, consult its
-[javadocs](https://codeintelligencetesting.github.io/jazzer-api/com/code_intelligence/jazzer/api/FuzzedDataProvider.html).
+[javadocs](https://codeintelligencetesting.github.io/jazzer-docs/jazzer-api/com/code_intelligence/jazzer/api/FuzzedDataProvider.html).


### PR DESCRIPTION
Updating URL to match move of jazzer-api docs into subdirectory https://github.com/CodeIntelligenceTesting/jazzer-docs/commit/45f9493727ce74c2fa1bf1d70affa04bd80ed2c2